### PR TITLE
Fix SQLite count verification

### DIFF
--- a/lib/tasks/migrate_to_sqlite.rake
+++ b/lib/tasks/migrate_to_sqlite.rake
@@ -193,7 +193,8 @@ namespace :db do
 
         pg_tables.each do |table_name|
           pg_count = pg_connection.exec("SELECT COUNT(*) FROM #{table_name}").getvalue(0, 0).to_i
-          sqlite_count = ActiveRecord::Base.connection.execute("SELECT COUNT(*) FROM #{table_name}").first[0]
+          sqlite_result = ActiveRecord::Base.connection.execute("SELECT COUNT(*) FROM #{table_name}")
+          sqlite_count = sqlite_result.first.first.to_i
 
           verification_results[table_name] = {
             postgresql: pg_count,


### PR DESCRIPTION
The verification step was failing because the SQLite count query result was not being properly accessed. Changed from `.first[0]` to `.first.first.to_i` to correctly extract the count value.

🤖 Generated with [Claude Code](https://claude.ai/code)