### PR TITLE
Fix Kamal healthcheck configuration syntax for Kamal 2.x

### DIFF
--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -13,6 +13,10 @@ servers:
   #     - 192.168.0.1
   #   cmd: bin/jobs
 
+# How long to wait for a container to become ready (seconds)
+# Increased to allow for database migrations during deployment
+deploy_timeout: 150
+
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
 #
@@ -20,15 +24,13 @@ servers:
 proxy:
   ssl: true
   host: contesthq.app
-
-# Configure health check for container readiness
-# Increased timeout to allow for database migrations during deployment
-healthcheck:
-  path: /up
-  port: 80
-  max_attempts: 15
-  interval: 10s
-  timeout: 150s
+  
+  # Configure health check for container readiness
+  # Increased timeout to allow for database migrations during deployment
+  healthcheck:
+    interval: 10    # Check every 10 seconds
+    path: /up       # Health check endpoint
+    timeout: 10     # Timeout for each health check request
 
 # Credentials for your image host.
 registry:


### PR DESCRIPTION
The previous healthcheck configuration was using incorrect syntax that caused deploy failures with 'unknown key: healthcheck' error.

Changes:
- Move healthcheck configuration under proxy section (Kamal 2.x requirement)
- Use integer values for interval/timeout instead of strings
- Add deploy_timeout at root level (150s) for overall deployment timeout
- Remove unsupported max_attempts and port options

Health check behavior:
- Checks /up endpoint every 10 seconds
- Each check times out after 10 seconds
- Overall deployment waits up to 150 seconds for container readiness
- Allows time for database migrations to complete during deployment